### PR TITLE
update_fos_alpha3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "stof/doctrine-extensions-bundle": "~1.2.1",
     "open-orchestra/open-orchestra-base-bundle": "self.version",
     "open-orchestra/open-orchestra-cms-bundle": "self.version",
-    "friendsofsymfony/user-bundle": "@dev"
+    "friendsofsymfony/user-bundle": "@alpha"
   },
 
   "require-dev": {


### PR DESCRIPTION
[OO-BCBREAK] version of friendsofsymfony/user-bundle is fixed to 2.0.0 alpha3

https://github.com/open-orchestra/open-orchestra-cms-bundle/pull/1801
https://github.com/open-orchestra/open-orchestra-elastica-bundle/pull/50
https://github.com/open-orchestra/open-orchestra-workflow-function-bundle/pull/141
https://github.com/open-orchestra/open-orchestra/pull/992
